### PR TITLE
24 format code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Events are in the form of (strings, value) and callbacks are in the form of clos
 #### Getting Started
 
 ```rust
-use async_event_emitter::AsyncEventEmitter;
-#[tokio::main]
-async fn main() {
-    let mut event_emitter = AsyncEventEmitter::new();
-    // This will print <"Hello world!"> whenever the <"Say Hello"> event is emitted
-    event_emitter.on("Say Hello", |_: ()| async move { println!("Hello world!") });
-    event_emitter.emit("Say Hello", ()).await.unwrap();
-    // >> "Hello world!"
-}
+    use async_event_emitter::AsyncEventEmitter;
+    #[tokio::main]
+    async fn main() {
+        let mut event_emitter = AsyncEventEmitter::new();
+        // This will print <"Hello world!"> whenever the <"Say Hello"> event is emitted
+        event_emitter.on("Say Hello", |_: ()| async move { println!("Hello world!") });
+        event_emitter.emit("Say Hello", ()).await.unwrap();
+        // >> "Hello world!"
+    }
 ```
 
 #### Basic Usage
@@ -40,7 +40,7 @@ A single EventEmitter instance can have listeners to values of multiple types.
 ```rust
     use async_event_emitter::AsyncEventEmitter as EventEmitter;
     use serde::{Deserialize, Serialize};
-    use
+
 
     #[tokio::main]
     async fn main() -> anyhow::Result<()> {
@@ -99,36 +99,36 @@ You'll likely want to have a single EventEmitter instance that can be shared acr
 After all, one of the main points of using an EventEmitter is to avoid passing down a value through several nested functions/types and having a global subscription service.
 
 ```rust
-// global_event_emitter.rs
-use async_event_emitter::AsyncEventEmitter;
-use futures::lock::Mutex;
-use lazy_static::lazy_static;
+        // global_event_emitter.rs
+        use async_event_emitter::AsyncEventEmitter;
+        use futures::lock::Mutex;
+        use lazy_static::lazy_static;
 
-// Use lazy_static! because the size of EventEmitter is not known at compile time
-lazy_static! {
-// Export the emitter with `pub` keyword
-pub static ref EVENT_EMITTER: Mutex<AsyncEventEmitter> = Mutex::new(AsyncEventEmitter::new());
-}
+        // Use lazy_static! because the size of EventEmitter is not known at compile time
+        lazy_static! {
+        // Export the emitter with `pub` keyword
+        pub static ref EVENT_EMITTER: Mutex<AsyncEventEmitter> = Mutex::new(AsyncEventEmitter::new());
+        }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // We need to maintain a lock through the mutex so we can avoid data races
-    EVENT_EMITTER
-        .lock()
-        .await
-        .on("Hello", |_: ()| async { println!("hello there!") });
-    EVENT_EMITTER.lock().await.emit("Hello", ()).await?;
+        #[tokio::main]
+        async fn main() -> anyhow::Result<()> {
+            // We need to maintain a lock through the mutex so we can avoid data races
+            EVENT_EMITTER
+                .lock()
+                .await
+                .on("Hello", |_: ()| async { println!("hello there!") });
+            EVENT_EMITTER.lock().await.emit("Hello", ()).await?;
 
-    Ok(())
-}
+            Ok(())
+        }
 
-async fn random_function() {
-    // When the <"Hello"> event is emitted in main.rs then print <"Random stuff!">
-    EVENT_EMITTER
-        .lock()
-        .await
-        .on("Hello", |_: ()| async { println!("Random stuff!") });
-}
+        async fn random_function() {
+            // When the <"Hello"> event is emitted in main.rs then print <"Random stuff!">
+            EVENT_EMITTER
+                .lock()
+                .await
+                .on("Hello", |_: ()| async { println!("Random stuff!") });
+        }
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ Events are in the form of (strings, value) and callbacks are in the form of clos
 
 ```rust
 use async_event_emitter::AsyncEventEmitter;
-
 #[tokio::main]
 async fn main() {
-let mut event_emitter = AsyncEventEmitter::new();
-// This will print <"Hello world!"> whenever the <"Say Hello"> event is emitted
-event_emitter.on("Say Hello", |_:()|  async move { println!("Hello world!")});
-event_emitter.emit("Say Hello", ()).await;
-// >> "Hello world!"
-
+    let mut event_emitter = AsyncEventEmitter::new();
+    // This will print <"Hello world!"> whenever the <"Say Hello"> event is emitted
+    event_emitter.on("Say Hello", |_: ()| async move { println!("Hello world!") });
+    event_emitter.emit("Say Hello", ()).await.unwrap();
+    // >> "Hello world!"
 }
 ```
 
@@ -84,14 +82,14 @@ A single EventEmitter instance can have listeners to values of multiple types.
 Removing listeners is also easy
 
 ```rust
-use async_event_emitter::AsyncEventEmitter as EventEmitter;
-let mut event_emitter = EventEmitter::new();
+    use async_event_emitter::AsyncEventEmitter as EventEmitter;
+    let mut event_emitter = EventEmitter::new();
 
-let listener_id = event_emitter.on("Hello", |_: ()|  async {println!("Hello World")});
-match event_emitter.remove_listener(&listener_id) {
-Some(listener_id) => print!("Removed event listener!"),
-None => print!("No event listener of that id exists")
-}
+    let listener_id = event_emitter.on("Hello", |_: ()| async { println!("Hello World") });
+    match event_emitter.remove_listener(&listener_id) {
+        Some(listener_id) => println!("Removed event listener! {listener_id}"),
+        None => println!("No event listener of that id exists"),
+    }
 ```
 
 #### Creating a Global EventEmitter

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### async-event-emitter
+
 [![Crates.io](https://img.shields.io/crates/v/async-event-emitter)](https://crates.io/crates/async-event-emitter)
 [![docs.rs](https://img.shields.io/docsrs/async-event-emitter)](https://docs.rs/async-event-emitter/0.1.1/async_event_emitter/)
 [![CI](https://github.com/spencerjibz/async-event-emitter-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/spencerjibz/async-event-emitter-rs/actions/workflows/ci.yml)
@@ -39,34 +40,45 @@ We can emit and listen to values of any type so long as they implement the Debug
 A single EventEmitter instance can have listeners to values of multiple types.
 
 ```rust
-use async_event_emitter::AsyncEventEmitter as EventEmitter;
-use serde::{Deserialize, Serialize};
-#[tokio::main]
-async fn main () {
-let mut event_emitter = EventEmitter::new();
-event_emitter.on("Add three", |number: f32| async move  {println!("{}", number + 3.0)});
-event_emitter.emit("Add three", 5.0 as f32).await;
-event_emitter.emit("Add three", 4.0 as f32).await;
+    use async_event_emitter::AsyncEventEmitter as EventEmitter;
+    use serde::{Deserialize, Serialize};
+    use
 
-// >> "8.0"
-// >> "7.0"
+    #[tokio::main]
+    async fn main() -> anyhow::Result<()> {
+        let mut event_emitter = EventEmitter::new();
+        event_emitter.on("Add three", |_number: f32| async move {
+            //println!("{}", number + 3.0)
+        });
+        event_emitter.emit("Add three", 5.0).await?;
+        event_emitter.emit("Add three", 4.0).await?;
 
-// Using a more advanced value type such as a struct by implementing the serde traits
-#[derive(Serialize, Deserialize,Debug)]
-struct Date {
-month: String,
-day: String,
-}
+        // >> "8.0"
+        // >> "7.0"
 
-event_emitter.on("LOG_DATE", |date: Date|  async move {
-println!("Month: {} - Day: {}", date.month, date.day)
-});
-event_emitter.emit("LOG_DATE", Date {
-month: "January".to_string(),
-day: "Tuesday".to_string()
-}).await;
-// >> "Month: January - Day: Tuesday"
-}
+        // Using a more advanced value type such as a struct by implementing the serde traits
+        #[derive(Serialize, Deserialize, Debug)]
+        struct Date {
+            month: String,
+            day: String,
+        }
+
+        event_emitter.on("LOG_DATE", |_date: Date| async move {
+            //println!("Month: {} - Day: {}", date.month, date.day)
+        });
+        event_emitter
+            .emit(
+                "LOG_DATE",
+                Date {
+                    month: "January".to_string(),
+                    day: "Tuesday".to_string(),
+                },
+            )
+            .await?;
+        // >> "Month: January - Day: Tuesday"
+
+        Ok(())
+    }
 ```
 
 Removing listeners is also easy
@@ -90,29 +102,38 @@ After all, one of the main points of using an EventEmitter is to avoid passing d
 
 ```rust
 // global_event_emitter.rs
-use lazy_static::lazy_static;
-use futures::lock::Mutex;
 use async_event_emitter::AsyncEventEmitter;
+use futures::lock::Mutex;
+use lazy_static::lazy_static;
 
 // Use lazy_static! because the size of EventEmitter is not known at compile time
 lazy_static! {
 // Export the emitter with `pub` keyword
 pub static ref EVENT_EMITTER: Mutex<AsyncEventEmitter> = Mutex::new(AsyncEventEmitter::new());
-}.
+}
 
 #[tokio::main]
-async fn main() {
-// We need to maintain a lock through the mutex so we can avoid data races
-EVENT_EMITTER.lock().await.on("Hello", |_:()|  async {println!("hello there!")});
-EVENT_EMITTER.lock().await.emit("Hello", ()).await;
+async fn main() -> anyhow::Result<()> {
+    // We need to maintain a lock through the mutex so we can avoid data races
+    EVENT_EMITTER
+        .lock()
+        .await
+        .on("Hello", |_: ()| async { println!("hello there!") });
+    EVENT_EMITTER.lock().await.emit("Hello", ()).await?;
+
+    Ok(())
 }
 
 async fn random_function() {
-// When the <"Hello"> event is emitted in main.rs then print <"Random stuff!">
-EVENT_EMITTER.lock().unwrap().on("Hello", |_: ()| async { println!("Random stuff!")});
+    // When the <"Hello"> event is emitted in main.rs then print <"Random stuff!">
+    EVENT_EMITTER
+        .lock()
+        .await
+        .on("Hello", |_: ()| async { println!("Random stuff!") });
 }
 
 ```
 
 #### License
+
 MIT License (MIT), see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ A single EventEmitter instance can have listeners to values of multiple types.
     use async_event_emitter::AsyncEventEmitter as EventEmitter;
     use serde::{Deserialize, Serialize};
 
-
     #[tokio::main]
     async fn main() -> anyhow::Result<()> {
         let mut event_emitter = EventEmitter::new();
-        event_emitter.on("Add three", |_number: f32| async move {
-            //println!("{}", number + 3.0)
+        event_emitter.on("Add three", |number: f64| async move {
+            println!("{}", number + 3.0)
         });
-        event_emitter.emit("Add three", 5.0).await?;
-        event_emitter.emit("Add three", 4.0).await?;
+
+        event_emitter.emit("Add three", 5.0_f64).await?;
+        event_emitter.emit("Add three", 4.0_f64).await?;
 
         // >> "8.0"
         // >> "7.0"
@@ -61,9 +61,10 @@ A single EventEmitter instance can have listeners to values of multiple types.
             day: String,
         }
 
-        event_emitter.on("LOG_DATE", |_date: Date| async move {
-            //println!("Month: {} - Day: {}", date.month, date.day)
-        });
+        event_emitter.on(
+            "LOG_DATE",
+            |_date: Date| async move { println!("{_date:?}") },
+        );
         event_emitter
             .emit(
                 "LOG_DATE",
@@ -73,6 +74,16 @@ A single EventEmitter instance can have listeners to values of multiple types.
                 },
             )
             .await?;
+        event_emitter
+            .emit(
+                "LOG_DATE",
+                Date {
+                    month: "February".to_string(),
+                    day: "Tuesday".to_string(),
+                },
+            )
+            .await?;
+        // >> "Month: January - Day: Tuesday"
         // >> "Month: January - Day: Tuesday"
 
         Ok(())


### PR DESCRIPTION
Example one doesn't work according,  adding a f32 suffix to each emitted value fixes the bug.